### PR TITLE
Accept non static string ref in custom constructor

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ pub struct Tab {
 /// The only purpose of this class is to get a `CdpConnection` which can be used
 /// to interact with the browser instance
 pub struct CdpClient {
-    host: &'static str,
+    host: String,
     port: u16,
 }
 impl CdpClient {
@@ -74,8 +74,8 @@ impl CdpClient {
     }
 
     /// Creates a new client connecting to a custom host and port
-    pub fn custom(host: &'static str, port: u16) -> Self {
-        Self { host, port }
+    pub fn custom(host: &str, port: u16) -> Self {
+        Self { host: host.to_string(), port }
     }
 
     /// Returns tabs from the browser instance


### PR DESCRIPTION
The host argument for the custom() constructor is a `&'static str`, preventing the use of any hostname that is not a static str.

This meant storing a clone of the string in CdpClient.
The other alternative would be to make the type generic to some other lifetime `CdpClient<'a>`.